### PR TITLE
Add loop, repeat, and random commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The following commands are currently implemented:
  * next
  * prev
  * clear
+ * loop
+ * repeat
+ * random
 
 ### volume
 

--- a/vlcclient.py
+++ b/vlcclient.py
@@ -182,6 +182,18 @@ class VLCClient(object):
         """Clear all items in playlist"""
         return self._send_command("clear")
 
+    def loop(self):
+        """Toggle loop"""
+        return self._send_command("loop")
+
+    def repeat(self):
+        """Toggle repeat of a single item"""
+        return self._send_command("repeat")
+
+    def random(self):
+        """Toggle random playback"""
+        return self._send_command("random")
+
     #
     # Volume
     #


### PR DESCRIPTION
Does what it says on the box. Was building a polybar module and figured these commands could be useful. Loop toggles whether the whole playlist will be looped, repeat toggles whether a single item will be played repeatedly, and random makes VLC shuffle the order that items will be played in (without disrupting the actual playlist order as seen in the GUI)